### PR TITLE
Create Order Logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'simple_form'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,9 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
+    simple_form (5.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -220,6 +223,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.beta3)
   sass-rails (~> 5)
   shoulda-matchers
+  simple_form
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,7 +4,7 @@ class OrdersController < ApplicationController
   # GET /orders
   # GET /orders.json
   def index
-    @orders = Order.all
+    @orders = Order.all.includes(:type)
   end
 
   # GET /orders/1
@@ -14,7 +14,7 @@ class OrdersController < ApplicationController
 
   # GET /orders/new
   def new
-    @order = Order.new
+    @order = Order.new(uuid: SecureRandom.uuid)
   end
 
   # GET /orders/1/edit
@@ -28,7 +28,7 @@ class OrdersController < ApplicationController
 
     respond_to do |format|
       if @order.save
-        format.html { redirect_to @order, notice: 'Order was successfully created.' }
+        format.html { redirect_to @order, notice: "Order ID: #{@order.uuid} was successfully created." }
         format.json { render :show, status: :created, location: @order }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class OrdersController < ApplicationController
   def update
     respond_to do |format|
       if @order.update(order_params)
-        format.html { redirect_to @order, notice: 'Order was successfully updated.' }
+        format.html { redirect_to @order, notice: "Order ID: #{@order.uuid} was successfully updated." }
         format.json { render :show, status: :ok, location: @order }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class OrdersController < ApplicationController
   def destroy
     @order.destroy
     respond_to do |format|
-      format.html { redirect_to orders_url, notice: 'Order was successfully destroyed.' }
+      format.html { redirect_to orders_url, notice: "Order ID: #{@order.uuid} was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,15 +1,21 @@
 class Order < ApplicationRecord
   VALID_COLORS = ['red', 'yellow', 'blue'].freeze
 
+  attr_readonly :uuid
+
   belongs_to :type
 
   validates_presence_of :quantity, :color, :deliver_by, :type_id
+  validates_uniqueness_of :uuid
   validates :color, inclusion: { in: VALID_COLORS }
   validates :quantity, numericality: {
     greater_than: 0,
     only_integer: true
   }
   validate :deliver_by_date_one_week_away
+  validate :prevent_update_if_uuid_present
+
+  before_create :assign_order_id
 
   # add deliver_by error if date diff is less than 7
   def deliver_by_date_one_week_away
@@ -19,5 +25,16 @@ class Order < ApplicationRecord
       :deliver_by,
       'is not at least 1 week away!'
     ) if ((deliver_by - Time.current)/1.day).round < 7
+  end
+
+  def assign_order_id
+    self.uuid ||= SecureRandom.uuid
+  end
+
+  def prevent_update_if_uuid_present
+    errors.add(
+      :uuid,
+      'cannot be updated!'
+    ) if uuid_changed? && self.persisted?
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,10 @@ class Order < ApplicationRecord
 
   validates_presence_of :quantity, :color, :deliver_by, :type_id
   validates :color, inclusion: { in: VALID_COLORS }
+  validates :quantity, numericality: {
+    greater_than_or_equal_to: 0,
+    only_integer: true
+  }
   validate :deliver_by_date_one_week_away
 
   # add deliver_by error if date diff is less than 7

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
   validates_presence_of :quantity, :color, :deliver_by, :type_id
   validates :color, inclusion: { in: VALID_COLORS }
   validates :quantity, numericality: {
-    greater_than_or_equal_to: 0,
+    greater_than: 0,
     only_integer: true
   }
   validate :deliver_by_date_one_week_away

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -5,4 +5,8 @@ class Type < ApplicationRecord
 
   validates_presence_of :name
   validates :name, inclusion: { in: VALID_WIDGET_TYPES }
+
+  def offical_name
+    name.split.map(&:capitalize)*' '
+  end
 end

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,17 +1,10 @@
-<%= form_with(model: order, local: true) do |form| %>
-  <% if order.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(order.errors.count, "error") %> prohibited this order from being saved:</h2>
-
-      <ul>
-        <% order.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
+<%= simple_form_for @order do |f| %>
+  <%= f.input :quantity, input_html: { min: 1 } %>
+  <%= f.input :color, collection: Order::VALID_COLORS %>
+  <%= f.input :deliver_by, as: :date,
+    start_year: Date.today.year,
+    order: [:day, :month, :year]
+  %>
+  <%= f.association :type, collection: Type.all %>
+  <%= f.button :submit %>
 <% end %>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -3,7 +3,7 @@
   <%= f.input :color, collection: Order::VALID_COLORS %>
   <%= f.input :deliver_by, as: :date,
     start_year: Date.today.year,
-    order: [:day, :month, :year]
+    order: [:month, :day, :year]
   %>
   <%= f.association :type, collection: Type.all %>
   <%= f.button :submit %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -2,30 +2,36 @@
 
 <h1>Orders</h1>
 
-<table>
-  <thead>
-    <tr>
-      <th colspan="1">ID</th>
-      <th colspan="1">Quantity</th>
-      <th colspan="1">Color</th>
-      <th colspan="1">Deliver By</th>
-      <th colspan="3">Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @orders.each do |order| %>
+<% if @orders %>
+  <table>
+    <thead>
       <tr>
-        <td><%= order.id %></td>
-        <td><%= order.quantity %></td>
-        <td><%= order.color %></td>
-        <td><%= order.deliver_by %></td>
-        <td><%= link_to 'Show', order %></td>
-        <td><%= link_to 'Edit', edit_order_path(order) %></td>
-        <td><%= link_to 'Destroy', order, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <th colspan="1">Quantity</th>
+        <th colspan="1">Color</th>
+        <th colspan="1">Type</th>
+        <th colspan="1">Deliver By</th>
+        <th colspan="1">Order ID</th>
+        <th colspan="3">Actions</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @orders.each do |order| %>
+        <tr>
+          <td><%= order.quantity %></td>
+          <td><%= order.color.capitalize %></td>
+          <td><%= order.type.offical_name %></td>
+          <td><%= order.deliver_by.strftime('%m/%d/%Y') %></td>
+          <td><%= order.uuid %></td>
+          <td><%= link_to 'Show', order %></td>
+          <td><%= link_to 'Edit', edit_order_path(order) %></td>
+          <td><%= link_to 'Destroy', order, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>There are no orders present!</p>
+<% end %>
 
 <br>
 

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -5,19 +5,21 @@
 <table>
   <thead>
     <tr>
-      <th colspan="1">ID</th>
       <th colspan="1">Quantity</th>
       <th colspan="1">Color</th>
+      <th colspan="1">Type</th>
       <th colspan="1">Deliver By</th>
+      <th colspan="1">Order ID</th>
       <th colspan="3">Actions</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><%= @order.id %></td>
       <td><%= @order.quantity %></td>
-      <td><%= @order.color %></td>
-      <td><%= @order.deliver_by %></td>
+      <td><%= @order.color.capitalize %></td>
+      <td><%= @order.type.offical_name %></td>
+      <td><%= @order.deliver_by.strftime('%m/%d/%Y') %></td>
+      <td><%= @order.uuid %></td>
       <td><%= link_to 'Show', @order %></td>
       <td><%= link_to 'Edit', edit_order_path(@order) %></td>
       <td><%= link_to 'Destroy', @order, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @types.each do |type| %>
       <tr>
-        <td><%= type.name %></td>
+        <td><%= type.offical_name %></td>
         <td><%= link_to 'Show', type %></td>
       </tr>
     <% end %>

--- a/app/views/types/show.html.erb
+++ b/app/views/types/show.html.erb
@@ -4,5 +4,5 @@
 
 <p>
   <strong>Name:</strong>
-  <%= @type.name %>
+  <%= @type.name.capitalize %>
 </p>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/db/migrate/20191025041254_create_orders.rb
+++ b/db/migrate/20191025041254_create_orders.rb
@@ -1,6 +1,7 @@
 class CreateOrders < ActiveRecord::Migration[6.0]
   def change
     create_table :orders do |t|
+      t.string :uuid, null: false, unique: true
       t.integer :quantity, null: false
       t.string :color, null: false
       t.datetime :deliver_by, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_041829) do
   enable_extension "plpgsql"
 
   create_table "orders", force: :cascade do |t|
+    t.string "uuid", null: false
     t.integer "quantity", null: false
     t.string "color", null: false
     t.datetime "deliver_by", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,12 +8,12 @@
 
 
 type_info = [{ name: 'widget' }, { name: 'widget pro' }, { name: 'widget xtreme' }]
-types = Type.create(type_info)
+types = Type.create!(type_info)
 colors = ['red', 'yellow', 'blue']
 dates = [Time.current + 1.weeks, Time.current + 2.weeks, Time.current + 3.weeks]
 
 10.times do
-  Order.create(
+  Order.create!(
     {
       quantity: rand(1..100),
       color: colors.sample,

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -88,6 +88,12 @@ RSpec.describe OrdersController, type: :controller do
         expect(order.quantity).to eql(20)
       end
 
+      it "does not update the order uuid" do
+        expect {
+          put :update, params: {id: order.id, order: new_attributes.merge(uuid: 'test123')}
+        }.to_not change(order, :uuid)
+      end
+
       it "redirects to the order" do
         put :update, params: {id: order.to_param, order: new_attributes}
         expect(response).to redirect_to(order)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Order, type: :model do
     [:quantity, :color, :deliver_by, :type_id].each do |field|
       it { expect(subject).to validate_presence_of(field) }
     end
+    it { expect(subject).to validate_uniqueness_of(:uuid) }
     it { expect(subject).to validate_numericality_of(:quantity).is_greater_than(0) }
     it { expect(subject).to validate_numericality_of(:quantity).only_integer }
 
@@ -24,6 +25,18 @@ RSpec.describe Order, type: :model do
 
       it 'vaidates that deliver by date is not in the future' do
         subject.deliver_by = Time.current - 2.weeks
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context 'dont allow uuid to be updated' do
+      it 'by being set to any other value' do
+        subject.uuid = SecureRandom.uuid
+        expect(subject.valid?).to be(false)
+      end
+
+      it 'by being set to nil' do
+        subject.uuid = nil
         expect(subject.valid?).to be(false)
       end
     end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Order, type: :model do
     [:quantity, :color, :deliver_by, :type_id].each do |field|
       it { expect(subject).to validate_presence_of(field) }
     end
-    it { expect(subject).to validate_numericality_of(:quantity).is_greater_than_or_equal_to(0) }
+    it { expect(subject).to validate_numericality_of(:quantity).is_greater_than(0) }
     it { expect(subject).to validate_numericality_of(:quantity).only_integer }
 
     context 'deliver by date validation' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Order, type: :model do
     [:quantity, :color, :deliver_by, :type_id].each do |field|
       it { expect(subject).to validate_presence_of(field) }
     end
+    it { expect(subject).to validate_numericality_of(:quantity).is_greater_than_or_equal_to(0) }
+    it { expect(subject).to validate_numericality_of(:quantity).only_integer }
 
     context 'deliver by date validation' do
       it 'vaidates that deliver by date is at least 1 week away' do

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Type, type: :model do
     it { expect(subject).to validate_presence_of(:name) }
     it { expect(subject).to validate_inclusion_of(:name).in_array(described_class::VALID_WIDGET_TYPES) }
   end
+
+  describe '.offical_name' do
+    let(:type) { create(:type, :xtreme) }
+
+    it { expect(type.offical_name).to eql('Widget Xtreme') }
+  end
 end

--- a/spec/views/orders/index.html.erb_spec.rb
+++ b/spec/views/orders/index.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "orders/index", type: :view do
 
   it "renders a list of orders" do
     render
-    assert_select "tr>td", :text => order1.id.to_s, :count => 1
-    assert_select "tr>td", :text => order2.id.to_s, :count => 1
+    assert_select "tr>td", :text => order1.uuid.to_s, :count => 1
+    assert_select "tr>td", :text => order2.uuid.to_s, :count => 1
   end
 end

--- a/spec/views/types/index.html.erb_spec.rb
+++ b/spec/views/types/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "types/index", type: :view do
 
   it "renders a list of types" do
     render
-    assert_select "tr>td", :text => "widget pro", :count => 1
-    assert_select "tr>td", :text => "widget xtreme", :count => 1
+    assert_select "tr>td", :text => type1.offical_name, :count => 1
+    assert_select "tr>td", :text => type2.offical_name, :count => 1
   end
 end


### PR DESCRIPTION
Create order utilizes simple form on the front end (handle validations,  builds form based off model, etc.) built in model validations and callback help set uuid upon creation and disallows the uuid to be altered. Updated views to include order uuid were necessary for notice functionality.