### PR TITLE
Add email confirmation logic

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -28,6 +28,8 @@ class OrdersController < ApplicationController
 
     respond_to do |format|
       if @order.save
+        OrderMailer.create_order(@order.id, @order.email).deliver_now if @order.email
+
         format.html { redirect_to @order, notice: "Order ID: #{@order.uuid} was successfully created." }
         format.json { render :show, status: :created, location: @order }
       else
@@ -78,7 +80,8 @@ class OrdersController < ApplicationController
       :quantity,
       :color,
       :deliver_by,
-      :type_id
+      :type_id,
+      :email
     )
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'notifications@widget.com'
   layout 'mailer'
 end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,0 +1,6 @@
+class OrderMailer < ApplicationMailer 
+  def create_order(id, email)
+    @order = Order.find(id)
+    mail(to: email, subject: 'Order Created!')
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,7 @@ class Order < ApplicationRecord
     greater_than: 0,
     only_integer: true
   }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validate :deliver_by_date_one_week_away
   validate :prevent_update_if_uuid_present
 

--- a/app/views/order_mailer/create_order.html.erb
+++ b/app/views/order_mailer/create_order.html.erb
@@ -1,0 +1,4 @@
+<h1>Order Created</h1>
+<h3>Order ID: <%= @order.uuid %></h3>
+<p>Order has been successfully created!</p>
+<p><%= link_to 'Order Details', @order %></p>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -6,5 +6,6 @@
     order: [:month, :day, :year]
   %>
   <%= f.association :type, collection: Type.all %>
+  <%= f.input :email %>
   <%= f.button :submit %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,11 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,11 @@ Rails.application.configure do
   config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
+  
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/db/migrate/20191028023812_add_email_to_orders.rb
+++ b/db/migrate/20191028023812_add_email_to_orders.rb
@@ -1,0 +1,5 @@
+class AddEmailToOrders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :orders, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_041829) do
+ActiveRecord::Schema.define(version: 2019_10_28_023812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_041829) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "type_id"
+    t.string "email"
     t.index ["type_id"], name: "index_orders_on_type_id"
   end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe OrdersController, type: :controller do
       type_id: type.id
     }
   }
+  let(:valid_attributes_with_email) {
+    {
+      quantity: 5,
+      color: Order::VALID_COLORS.sample,
+      deliver_by: Time.current + 1.week,
+      type_id: type.id,
+      email: 'test@email.com'
+    }
+  }
   let(:invalid_attributes) {
     {
       quantity: -1,
@@ -54,6 +63,14 @@ RSpec.describe OrdersController, type: :controller do
         expect {
           post :create, params: { order: valid_attributes }
         }.to change(Order, :count).by(1)
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it "creates a new Order with email present" do
+        expect {
+          post :create, params: { order: valid_attributes_with_email }
+        }.to change(Order, :count).by(1)
+        expect(ActionMailer::Base.deliveries).to_not be_empty
       end
 
       it "redirects to the created order" do

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe OrderMailer, type: :mailer do
+  let(:order) { create(:order, email: 'test@email.com') }
+
+  describe '.create_order' do
+    let!(:email) { OrderMailer.create_order(order.id, order.email).deliver }
+
+    it { expect(email.to).to eq([order.email]) }
+    it { expect(email.subject).to eq('Order Created!') }
+    it { expect(email.body.encoded).to include(order.uuid) }
+    it { expect(ActionMailer::Base.deliveries).not_to be_empty }
+  end
+end

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/order_mailer
+class OrderMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Order, type: :model do
     it { expect(subject).to validate_uniqueness_of(:uuid) }
     it { expect(subject).to validate_numericality_of(:quantity).is_greater_than(0) }
     it { expect(subject).to validate_numericality_of(:quantity).only_integer }
+    it { is_expected.to allow_value("email@address.foo").for(:email) }
+    it { is_expected.to_not allow_value("foo").for(:email) }
 
     context 'deliver by date validation' do
       it 'vaidates that deliver by date is at least 1 week away' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,5 +92,7 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end 
+=end
+
+  config.order = 'random'
 end


### PR DESCRIPTION
Send an email confirmation to a user if they input an email during order creation. If no email, it's no big deal. We still would like only valid emails though.